### PR TITLE
Issue 1: watch non-yet-existing markdown files

### DIFF
--- a/handler/filerender.go
+++ b/handler/filerender.go
@@ -55,6 +55,18 @@ func renderMarkDown(w http.ResponseWriter, r *http.Request, path string) error {
 	return err
 }
 
+func renderNotFound(w http.ResponseWriter, r *http.Request, path string) error {
+	var err error
+
+	err = tmpl.ExecuteTemplate(w, "tmpl/markdown.tmpl", map[string]interface{}{
+		"rand":       rand.Int(),
+		"css":        flagMdCSS,
+		"path":       path,
+		"outputHTML": template.HTML("File not found"),
+	})
+	return err
+}
+
 func renderFolder(w http.ResponseWriter, r *http.Request, path string) error {
 	res, err := ioutil.ReadDir(path)
 	if err != nil {

--- a/handler/handlers.go
+++ b/handler/handlers.go
@@ -84,9 +84,13 @@ func fileServe(w http.ResponseWriter, r *http.Request) {
 
 	fstat, err := os.Stat(path)
 	if err != nil {
-		err := renderNotFound(w, r, path)
-		if err != nil {
-			webu.WriteStatus(w, http.StatusInternalServerError, err)
+		if filepath.Ext(path) == ".md" {
+			err := renderNotFound(w, r, path)
+			if err != nil {
+				webu.WriteStatus(w, http.StatusInternalServerError, err)
+			}
+		} else {
+            		webu.WriteStatus(w, http.StatusNotFound)
 		}
 		return
 	}


### PR DESCRIPTION
Renders a not-found page for non-existent markdown files, thereby automatically watching them.
If a watched file does not exist, try watching its parent(s). (issue #1)